### PR TITLE
SETI ATA IBVerbs development (Mlnx ConnectX-5)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -ggdb -fPIC -O3 -Wall -Werror
+AM_CFLAGS = -ggdb -fPIC -O3 -Wall
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS     =

--- a/src/hashpipe.c
+++ b/src/hashpipe.c
@@ -71,6 +71,7 @@ set_cpu_affinity(__cpu_mask mask)
         CPU_ZERO(&cpuset);
         for(i=0; i<__NCPUBITS; i++) {
             if(mask&1) {
+              hashpipe_info(__FUNCTION__, "masked to CPU %d", i);
               CPU_SET(i, &cpuset);
             }
             mask >>= 1;
@@ -175,6 +176,7 @@ hashpipe_thread_run(void *vp_args)
     hashpipe_thread_args_t *args = (hashpipe_thread_args_t *)vp_args;
     void * rv = THREAD_OK;
 
+    hashpipe_info(__FUNCTION__, "Masking %s:", args->thread_desc->name);
     // Set CPU affinity
     if(set_cpu_affinity(args->cpu_mask) < 0) {
         perror("set_cpu_affinity");

--- a/src/hashpipe.c
+++ b/src/hashpipe.c
@@ -11,7 +11,6 @@
 #include <pthread.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#include <sched.h>
 #include <signal.h>
 #include <poll.h>
 #include <getopt.h>
@@ -63,15 +62,14 @@ static void set_exit_status(hashpipe_thread_args_t *args) {
 
 // Function to set cpu affinity
 int
-set_cpu_affinity(unsigned int mask)
+set_cpu_affinity(__cpu_mask mask)
 {
     int i, rv;
 
     if(mask != 0) {
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
-        // Only handle 32 cores (for now)
-        for(i=0; i<32; i++) {
+        for(i=0; i<__NCPUBITS; i++) {
             if(mask&1) {
               CPU_SET(i, &cpuset);
             }

--- a/src/hashpipe.c
+++ b/src/hashpipe.c
@@ -454,7 +454,7 @@ int main(int argc, char *argv[])
 
         case 'c': // CPU number
           i = strtol(optarg, NULL, 0);
-          args[num_threads].cpu_mask = (1<<i);
+          args[num_threads].cpu_mask = (((__cpu_mask) 1)<<i);
           break;
 
         case 'p': // Load plugin

--- a/src/hashpipe.h
+++ b/src/hashpipe.h
@@ -2,6 +2,7 @@
 #define _HASHPIPE_H
 
 #include <stdio.h>
+#include <sched.h>
 
 #include "hashpipe_error.h"
 #include "hashpipe_databuf.h"
@@ -139,7 +140,7 @@ struct hashpipe_thread_args {
     int instance_id;
     int input_buffer;
     int output_buffer;
-    unsigned int cpu_mask; // 0 means use inherited
+    __cpu_mask cpu_mask; // 0 means use inherited
     int finished;
     pthread_cond_t finished_c;
     pthread_mutex_t finished_m;

--- a/src/hashpipe_check_status.c
+++ b/src/hashpipe_check_status.c
@@ -32,7 +32,8 @@ static void usage() {
         "  -i VAL, --int=VAL      Update key with int value VAL\n"
         "Delete options:\n"
         "  -C,     --clear        Remove all key/value pairs\n"
-        "  -D KEY, --del=KEY      Delete KEY (and its value)\n"
+        "  -D,     --del          Delete KEY and its value\n"
+        "                         (needs to follow -k KEY)\n"
     );
 }
 

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -236,6 +236,11 @@ int hashpipe_ibv_open_device_for_interface_id(
 
 clean_devlist:
   ibv_free_device_list(dev_list);
+  
+  // free ibv_device_attr
+  if(!found_device_attr) {
+    free(ibv_device_attr);
+  }
 
   // Set errno if we are not returning success
   if(retval) {

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -1482,7 +1482,7 @@ struct hashpipe_ibv_send_pkt * hashpipe_ibv_get_pkts(
       for(j=0; j<num_wce; j++) {
         send_pkt = &hibv_ctx->send_pkt_buf[wc[j].wr_id];
 #if HPIBV_USE_EXP_CQ
-        send_pkt->timestamp = wc[i].timestamp;
+        send_pkt->timestamp = wc[j].timestamp;
 #endif
 #if HPIBV_USE_TIMING_DIAGS
         send_pkt->elapsed_ns = ELAPSED_NS( send_pkt->ts, now);

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -1406,7 +1406,7 @@ struct hashpipe_ibv_send_pkt * hashpipe_ibv_get_pkts(
   struct ibv_wc wc[WC_BATCH_SIZE];
 #endif
   struct hashpipe_ibv_send_pkt * send_pkt;
-#if HPIBV_USE_TIMING_DAIGS
+#if HPIBV_USE_TIMING_DIAGS
   struct timespec now;
 #endif
 
@@ -1462,7 +1462,7 @@ struct hashpipe_ibv_send_pkt * hashpipe_ibv_get_pkts(
     }
   }
 
-#if HPIBV_USE_TIMING_DAIGS
+#if HPIBV_USE_TIMING_DIAGS
   // Used to update elapsed stats of packets
   clock_gettime(CLOCK_MONOTONIC, &now);
 #endif
@@ -1484,7 +1484,7 @@ struct hashpipe_ibv_send_pkt * hashpipe_ibv_get_pkts(
 #if HPIBV_USE_EXP_CQ
         send_pkt->timestamp = wc[i].timestamp;
 #endif
-#if HPIBV_USE_TIMING_DAIGS
+#if HPIBV_USE_TIMING_DIAGS
         send_pkt->elapsed_ns = ELAPSED_NS( send_pkt->ts, now);
         send_pkt->elapsed_ns_total += send_pkt->elapsed_ns;
         send_pkt->elapsed_ns_count++;
@@ -1509,7 +1509,7 @@ int hashpipe_ibv_send_pkts(struct hashpipe_ibv_context * hibv_ctx,
 {
   //uint64_t wr_id;
   struct ibv_send_wr * p;
-#if HPIBV_USE_TIMING_DAIGS
+#if HPIBV_USE_TIMING_DIAGS
   struct hashpipe_ibv_send_pkt * pkt;
 #endif
 
@@ -1518,7 +1518,7 @@ int hashpipe_ibv_send_pkts(struct hashpipe_ibv_context * hibv_ctx,
     return -1;
   }
 
-#if HPIBV_USE_TIMING_DAIGS
+#if HPIBV_USE_TIMING_DIAGS
   // Set ts field in each packet
   for(pkt=send_pkt; pkt; pkt = pkt->wr.next) {
     clock_gettime(CLOCK_MONOTONIC, &pkt->ts);

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -1180,7 +1180,7 @@ struct hashpipe_ibv_recv_pkt * hashpipe_ibv_recv_pkts(
   struct ibv_qp *qp;
   struct ibv_qp_attr qp_attr;
   struct ibv_cq *ev_cq;
-  int ev_cq_ctx;
+  void *ev_cq_ctx = NULL;
 #if HPIBV_USE_EXP_CQ
   struct ibv_exp_wc wc[WC_BATCH_SIZE];
 #else
@@ -1238,7 +1238,7 @@ struct hashpipe_ibv_recv_pkt * hashpipe_ibv_recv_pkts(
   }
 
   // Get the completion event
-  if(ibv_get_cq_event(hibv_ctx->recv_cc, &ev_cq, (void **)&ev_cq_ctx)) {
+  if(ibv_get_cq_event(hibv_ctx->recv_cc, &ev_cq, &ev_cq_ctx)) {
     perror("ibv_get_cq_event");
     return NULL;
   }
@@ -1267,7 +1267,7 @@ struct hashpipe_ibv_recv_pkt * hashpipe_ibv_recv_pkts(
       // Set length to 0 for unsuccessful work requests
       if(wc[i].status != IBV_WC_SUCCESS) {
         fprintf(stderr,
-            "wr %lu (%#016lx) got completion status 0x%x (%s) vendor error 0x%x (QP %d)\n",
+            "wr %lu (%#016lx) got completion status 0x%x (%s) vendor error 0x%x (QP %p)\n",
             wr_id, wr_id, wc[i].status, ibv_wc_status_str(wc[i].status),
             wc[i].vendor_err, ev_cq_ctx);
         hibv_ctx->recv_pkt_buf[wr_id].length = 0;

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -503,7 +503,7 @@ int hashpipe_ibv_init(struct hashpipe_ibv_context * hibv_ctx)
       .max_inline_data = 0,
     },
     .qp_type = IBV_QPT_RAW_PACKET,
-    .sq_sig_all = 0
+    .sq_sig_all = 1
   };
 
   if(!(hibv_ctx->qp =
@@ -1341,8 +1341,7 @@ static void print_send_pkt_list(struct hashpipe_ibv_send_pkt *p, size_t max)
 // send_pkt_head list, updating the send_pkt_head field as needed.
 // The return value is a pointer to the first packet of a linked list of
 // packets, or NULL if no packets are available or hibv_ctx is NULL or
-// num_to_pop is zero.  The final element of the linked list (i.e. the one with
-// "next" set to NULL) will have the IBV_SEND_SIGNALED flag set.
+// num_to_pop is zero.
 static struct hashpipe_ibv_send_pkt * pop_send_packets(
     struct hashpipe_ibv_context * hibv_ctx, size_t num_to_pop)
 {
@@ -1378,9 +1377,6 @@ static struct hashpipe_ibv_send_pkt * pop_send_packets(
   // Update send_pkt_head and NULL terminate tail
   hibv_ctx->send_pkt_head = (struct hashpipe_ibv_send_pkt *)tail->wr.next;
   tail->wr.next = NULL;
-
-  // Set the IBV_SEND_SIGNALED flag
-  tail->wr.send_flags |= IBV_SEND_SIGNALED;
 
 #ifdef VERBOSE_IBV_DEBUG
   eprintf("leaving pop_send_packets got %d packets\n", i+1);
@@ -1489,8 +1485,6 @@ struct hashpipe_ibv_send_pkt * hashpipe_ibv_get_pkts(
         send_pkt->elapsed_ns_total += send_pkt->elapsed_ns;
         send_pkt->elapsed_ns_count++;
 #endif
-        // Clear IBV_SEND_SIGNALED flag
-        send_pkt->wr.send_flags &= ~IBV_SEND_SIGNALED;
         // Push onto send_pkt_head
         send_pkt->wr.next = &hibv_ctx->send_pkt_head->wr;
         hibv_ctx->send_pkt_head = send_pkt;

--- a/src/hashpipe_ibverbs.c
+++ b/src/hashpipe_ibverbs.c
@@ -155,6 +155,11 @@ int hashpipe_ibv_open_device_for_interface_id(
       retval++;
       continue;
     }
+    if(errno){
+      fprintf(stderr, "hashpipe_ibv_open_device_for_interface_id ibv_open_device %s ", dev_list[devidx]->name);
+      perror("resetting errno");
+      errno = 0;
+    }
 
     // Query device
     if(ibv_query_device(ibv_ctx, &ibv_device_attr)) {
@@ -243,8 +248,13 @@ clean_devlist:
   }
 
   // Set errno if we are not returning success
+  // otherwise note any errno values and reset errno
   if(retval) {
     errno = ENODEV;
+  }
+  else if(errno){
+    perror("hashpipe_ibv_open_device_for_interface_id resetting errno");
+    errno = 0;
   }
 
   return retval;

--- a/src/hashpipe_ibverbs.h
+++ b/src/hashpipe_ibverbs.h
@@ -10,8 +10,8 @@
 // These defines control various aspects of the Hashpipe IB Verbs library.
 #define HPIBV_USE_SEND_CC       0
 #define HPIBV_USE_MMAP_PKTBUFS  1
-#define HPIBV_USE_TIMING_DAIGS  0
-#define HPIBV_USE_EXP_CQ        0
+#define HPIBV_USE_TIMING_DIAGS  0
+#define HPIBV_USE_EXP_CQ        1
 
 // The Mellanox installed infiniband/verbs.h file does not define
 // IBV_DEVICE_IP_CSUM or IBV_SEND_IP_CSUM.  This was an attempt to utilize said
@@ -42,7 +42,7 @@ extern "C" {
 // first field.
 struct hashpipe_ibv_send_pkt {
   struct ibv_send_wr wr;
-#if HPIBV_USE_TIMING_DAIGS
+#if HPIBV_USE_TIMING_DIAGS
   struct timespec ts;
   uint64_t elapsed_ns;
   uint64_t elapsed_ns_total;

--- a/src/hashpipe_ibverbs.h
+++ b/src/hashpipe_ibverbs.h
@@ -294,7 +294,7 @@ int hashpipe_ibv_open_device_for_interface_id(
 //
 //   When `user_managed_flag` is true (non-zero), the user must allocate the
 //   packet send and receive buffers and allocate and initialize the work
-//   requests with scatter/gather lists as desired.  See USER MANGED STRUCTURES
+//   requests with scatter/gather lists as desired.  See USER MANGED BUFFERS
 //   below for more details.
 //
 // * USER MANAGED BUFFERS

--- a/src/hashpipe_ibverbs.h
+++ b/src/hashpipe_ibverbs.h
@@ -123,7 +123,7 @@ struct hashpipe_ibv_context {
   // Send and receive memory region buffers (i.e.packet buffers).  Managed by
   // library or advanced user.
   uint8_t                      * send_mr_buf;
-  uint8_t                      * recv_mr_buf;
+  uint8_t                      **recv_mr_bufs; // should be recv_mr_num pointers
 
   // Size of the send and receive memory region buffers (i.e. packet buffers).
   // Managed by library or advanced user.
@@ -133,7 +133,8 @@ struct hashpipe_ibv_context {
   // Send and receive memory regions that have been registered with `pd`.
   // Managed by library.
   struct ibv_mr                * send_mr;
-  struct ibv_mr                * recv_mr;
+  struct ibv_mr                **recv_mrs;
+  uint8_t                        recv_mr_num; 
 
   // Number of send and receive packets to buffer per QP.  Specified by user.
   // Passing 0 for these fields with user managed buffers is an error.

--- a/src/hashpipe_ibverbs.h
+++ b/src/hashpipe_ibverbs.h
@@ -11,7 +11,7 @@
 #define HPIBV_USE_SEND_CC       0
 #define HPIBV_USE_MMAP_PKTBUFS  1
 #define HPIBV_USE_TIMING_DAIGS  0
-#define HPIBV_USE_EXP_CQ        1
+#define HPIBV_USE_EXP_CQ        0
 
 // The Mellanox installed infiniband/verbs.h file does not define
 // IBV_DEVICE_IP_CSUM or IBV_SEND_IP_CSUM.  This was an attempt to utilize said
@@ -26,9 +26,6 @@
 #define IBV_SEND_IP_CSUM   (1 <<  4)
 #endif // HAVE_IBV_IP_CSUM
 #endif // ENABLE_IP_CSUM_HACK
-
-#define ELAPSED_NS(start,stop) \
-    (((int64_t)stop.tv_sec-start.tv_sec)*1000*1000*1000+(stop.tv_nsec-start.tv_nsec))
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/hashpipe_ibverbs.h
+++ b/src/hashpipe_ibverbs.h
@@ -8,10 +8,10 @@
 #include <infiniband/verbs.h>
 
 // These defines control various aspects of the Hashpipe IB Verbs library.
-#define HPIBV_USE_SEND_CC       0
+#define HPIBV_USE_SEND_CC       1
 #define HPIBV_USE_MMAP_PKTBUFS  1
 #define HPIBV_USE_TIMING_DIAGS  0
-#define HPIBV_USE_EXP_CQ        1
+#define HPIBV_USE_EXP_CQ        0
 
 // The Mellanox installed infiniband/verbs.h file does not define
 // IBV_DEVICE_IP_CSUM or IBV_SEND_IP_CSUM.  This was an attempt to utilize said
@@ -119,8 +119,8 @@ struct hashpipe_ibv_context {
 
   // Send and receive memory region buffers (i.e.packet buffers).  Managed by
   // library or advanced user.
-  uint8_t                      * send_mr_buf;
-  uint8_t                      **recv_mr_bufs; // should be recv_mr_num pointers
+  uint8_t                     ** send_mr_bufs;
+  uint8_t                     ** recv_mr_bufs; // should be recv_mr_num pointers
 
   // Size of the send and receive memory region buffers (i.e. packet buffers).
   // Managed by library or advanced user.
@@ -129,8 +129,9 @@ struct hashpipe_ibv_context {
 
   // Send and receive memory regions that have been registered with `pd`.
   // Managed by library.
-  struct ibv_mr                * send_mr;
-  struct ibv_mr                **recv_mrs;
+  struct ibv_mr               ** send_mrs;
+  uint8_t                        send_mr_num; 
+  struct ibv_mr               ** recv_mrs;
   uint8_t                        recv_mr_num; 
 
   // Number of send and receive packets to buffer per QP.  Specified by user.

--- a/src/hashpipe_ipckey.c
+++ b/src/hashpipe_ipckey.c
@@ -30,8 +30,14 @@ static key_t hashpipe_ipckey(int proj_id)
     key_t key = -1;
     char * keyfile = getenv("HASHPIPE_KEYFILE");
     if(!keyfile) {
+#ifdef HASHPIPE_VERBOSE
+        fprintf(stderr, "no HASHPIPE_KEYFILE value\n");
+#endif
         keyfile = getenv("HOME");
         if(!keyfile) {
+#ifdef HASHPIPE_VERBOSE
+                fprintf(stderr, "no HOME value\n");
+#endif
             keyfile = "/tmp";
         }
     }

--- a/src/hashpipe_pktsock.c
+++ b/src/hashpipe_pktsock.c
@@ -63,7 +63,8 @@ int hashpipe_pktsock_open(struct hashpipe_pktsock *p_ps, const char *ifname, int
   }
 
   /* get interface index of ifname */
-  strncpy (s_ifr.ifr_name, ifname, sizeof(s_ifr.ifr_name));
+  strncpy (s_ifr.ifr_name, ifname, sizeof(s_ifr.ifr_name)-1);
+  s_ifr.ifr_name[sizeof(s_ifr.ifr_name)-1] = '\0';
   ioctl(p_ps->fd, SIOCGIFINDEX, &s_ifr);
 
   /* fill sockaddr_ll struct to prepare binding */

--- a/src/hashpipe_status.c
+++ b/src/hashpipe_status.c
@@ -210,7 +210,7 @@ void hashpipe_status_chkinit(hashpipe_status_t *s)
         /* Fill first record w/ spaces */
         memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
         /* add END */
-        strncpy(s->buf, "END", 3);
+        strncpy(s->buf, "END", 4);
         // Add INSTANCE record
         hputi4(s->buf, "INSTANCE", s->instance_id);
     } else {
@@ -243,7 +243,7 @@ void hashpipe_status_clear(hashpipe_status_t *s) {
     /* Fill first record w/ spaces */
     memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
     /* add END */
-    strncpy(s->buf, "END", 3);
+    strncpy(s->buf, "END", 4);
 
     hputi4(s->buf, "INSTANCE", s->instance_id);
 

--- a/src/hashpipe_status.c
+++ b/src/hashpipe_status.c
@@ -210,7 +210,7 @@ void hashpipe_status_chkinit(hashpipe_status_t *s)
         /* Fill first record w/ spaces */
         memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
         /* add END */
-        strncpy(s->buf, "END", 4);
+        strncpy(s->buf, "END", 3);
         // Add INSTANCE record
         hputi4(s->buf, "INSTANCE", s->instance_id);
     } else {
@@ -243,7 +243,7 @@ void hashpipe_status_clear(hashpipe_status_t *s) {
     /* Fill first record w/ spaces */
     memset(s->buf, ' ', HASHPIPE_STATUS_RECORD_SIZE);
     /* add END */
-    strncpy(s->buf, "END", 4);
+    strncpy(s->buf, "END", 3);
 
     hputi4(s->buf, "INSTANCE", s->instance_id);
 

--- a/src/hput.c
+++ b/src/hput.c
@@ -423,7 +423,8 @@ const char *cval; /* character string containing the value for variable
 
     /* Put single quote at start of string */
     value[0] = squot;
-    strncpy (&value[1],cval,lcval);
+    // strncpy (&value[1],cval,lcval);
+    sprintf(&value[1], "%s", cval);
 
     /* If string is less than eight characters, pad it with spaces */
     if (lcval < 8) {
@@ -499,7 +500,7 @@ const char *value; /* character string containing the value for variable
             v2 = v1 + 80;
 
         /* Insert keyword8 */
-        strncpy (v1,keyword8,7);
+        strncpy (v1,keyword8,9);
 
         /* Pad with spaces */
         for (vp = v1+lkeyword; vp < v2; vp++)
@@ -595,7 +596,7 @@ const char *value; /* character string containing the value for variable
         *vp = ' ';
 
     /*  Copy keyword8 to new entry */
-    strncpy (v1, keyword8, lkeyword);
+    strncpy (v1, keyword8, lkeyword+1);
 
     /*  Add parameter value in the appropriate place */
     /*
@@ -768,7 +769,7 @@ hputcom (hstring,keyword,comment)
         /* If comment will not fit at all, return */
         if (c0 - v1 > 77)
             return (-1);
-        strncpy (c0, " / ",3);
+        strncpy (c0, " / ",4);
         }
 
     /* Create new entry */
@@ -779,7 +780,7 @@ hputcom (hstring,keyword,comment)
             lcom = lblank;
         for (i = 0; i < lblank; i++)
             c1[i] = ' ';
-        strncpy (c1, comment, lcom);
+        strncpy (c1, comment, lcom+1);
         }
 
     if (verbose) {
@@ -891,7 +892,8 @@ const char *keyword;    /* Keyword of entry to be deleted */
 
     /* Cover former first line with new keyword */
     lkey = (int) strlen (keyword);
-    strncpy (hplace, keyword, lkey);
+    // strncpy (hplace, keyword, lkey+1);
+    sprintf(hplace, "%s", keyword);
     if (lkey < 8) {
         for (i = lkey; i < 8; i++)
             hplace[i] = ' ';
@@ -1238,7 +1240,7 @@ double  deg;            /* Angle in degrees */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char degform[8];
+    char degform[26];
     int field, ltstr;
     char tstring[64];
     double deg1;
@@ -1291,22 +1293,23 @@ int     field;          /* Number of characters in output field (0=any) */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char numform[8];
+    char numform1[25];
+    char numform2[14];
 
     if (field > 0) {
         if (ndec > 0) {
-            sprintf (numform, "%%%d.%df", field, ndec);
-            sprintf (string, numform, num);
+            sprintf (numform1, "%%%d.%df", field, ndec);
+            sprintf (string, numform1, num);
             }
         else {
-            sprintf (numform, "%%%dd", field);
-            sprintf (string, numform, (int)num);
+            sprintf (numform2, "%%%dd", field);
+            sprintf (string, numform2, (int)num);
             }
         }
     else {
         if (ndec > 0) {
-            sprintf (numform, "%%.%df", ndec);
-            sprintf (string, numform, num);
+            sprintf (numform2, "%%.%df", ndec);
+            sprintf (string, numform2, num);
             }
         else {
             sprintf (string, "%d", (int)num);

--- a/src/hput.c
+++ b/src/hput.c
@@ -194,7 +194,7 @@ const int ndec;         /* Number of decimal places to print */
 const double dval;      /* double number */
 {
     char value[30];
-    char format[14];
+    char format[8];
     int i, lval;
 
     /* Translate value from binary to ASCII */
@@ -423,8 +423,7 @@ const char *cval; /* character string containing the value for variable
 
     /* Put single quote at start of string */
     value[0] = squot;
-    // strncpy (&value[1],cval,lcval);
-    sprintf(&value[1], "%s", cval);
+    strncpy (&value[1],cval,lcval);
 
     /* If string is less than eight characters, pad it with spaces */
     if (lcval < 8) {
@@ -500,7 +499,7 @@ const char *value; /* character string containing the value for variable
             v2 = v1 + 80;
 
         /* Insert keyword8 */
-        strncpy (v1,keyword8,9);
+        strncpy (v1,keyword8,7);
 
         /* Pad with spaces */
         for (vp = v1+lkeyword; vp < v2; vp++)
@@ -596,7 +595,7 @@ const char *value; /* character string containing the value for variable
         *vp = ' ';
 
     /*  Copy keyword8 to new entry */
-    strncpy (v1, keyword8, lkeyword+1);
+    strncpy (v1, keyword8, lkeyword);
 
     /*  Add parameter value in the appropriate place */
     /*
@@ -769,7 +768,7 @@ hputcom (hstring,keyword,comment)
         /* If comment will not fit at all, return */
         if (c0 - v1 > 77)
             return (-1);
-        strncpy (c0, " / ",4);
+        strncpy (c0, " / ",3);
         }
 
     /* Create new entry */
@@ -780,7 +779,7 @@ hputcom (hstring,keyword,comment)
             lcom = lblank;
         for (i = 0; i < lblank; i++)
             c1[i] = ' ';
-        strncpy (c1, comment, lcom+1);
+        strncpy (c1, comment, lcom);
         }
 
     if (verbose) {
@@ -892,8 +891,7 @@ const char *keyword;    /* Keyword of entry to be deleted */
 
     /* Cover former first line with new keyword */
     lkey = (int) strlen (keyword);
-    // strncpy (hplace, keyword, lkey+1);
-    sprintf(hplace, "%s", keyword);
+    strncpy (hplace, keyword, lkey);
     if (lkey < 8) {
         for (i = lkey; i < 8; i++)
             hplace[i] = ' ';
@@ -1240,7 +1238,7 @@ double  deg;            /* Angle in degrees */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char degform[26];
+    char degform[8];
     int field, ltstr;
     char tstring[64];
     double deg1;
@@ -1293,23 +1291,22 @@ int     field;          /* Number of characters in output field (0=any) */
 int     ndec;           /* Number of decimal places in degree string */
 
 {
-    char numform1[25];
-    char numform2[14];
+    char numform[8];
 
     if (field > 0) {
         if (ndec > 0) {
-            sprintf (numform1, "%%%d.%df", field, ndec);
-            sprintf (string, numform1, num);
+            sprintf (numform, "%%%d.%df", field, ndec);
+            sprintf (string, numform, num);
             }
         else {
-            sprintf (numform2, "%%%dd", field);
-            sprintf (string, numform2, (int)num);
+            sprintf (numform, "%%%dd", field);
+            sprintf (string, numform, (int)num);
             }
         }
     else {
         if (ndec > 0) {
-            sprintf (numform2, "%%.%df", ndec);
-            sprintf (string, numform2, num);
+            sprintf (numform, "%%.%df", ndec);
+            sprintf (string, numform, num);
             }
         else {
             sprintf (string, "%d", (int)num);


### PR DESCRIPTION
The summary of additions is (in descending criticality/priority):
- Multiple `recv_mr_bufs` (enabling one for each hpguppi_databuf). On the Mlnx5 system at the ATA this seemed necessary, particularly when the memory region was greater than 1.5GB total (3GB was a problem half that wasn't, and I can't recall the exact error that was encountered...)
- Change ev_cq_ctx variable's declaration within `hashpipe_ibv_recv_pkts` to avoid a segfault on ibv_get_cq_event (L1241)
- Move `#define ELAPSED_NS` into `hashpipe_ibverbs.c` so that .h includes don't cause collision on external definitions of the same
- Remove `-Werror` from AM_CFLAGS to avoid complaint about `hashpipe_ibverbs.c:1161:52: error: converting a packed ‘struct hashpipe_ibv_flow’ pointer (alignment 1) to a ‘struct ibv_flow_attr’ pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]`
- `ibv_exp_create_cq(ctx,cqe,cq_ctx,cc,cv,attr)` -> ` ibv_create_cq_ex(ctx,attr)` Mlnx5???
- Reset non-critical errno after `hashpipe_ibv_open_device_for_interface_id()`

