### PR TITLE
treat some errors as warnings to make gcc 11 happy

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,6 @@
-AM_CFLAGS = -ggdb -fPIC -O3 -Wall -Werror
+AM_CFLAGS = -ggdb -fPIC -O3 -Wall -Werror \
+            -Wno-error=stringop-truncation \
+            -Wno-error=format-overflow
 ACLOCAL_AMFLAGS = -I m4
 
 bin_PROGRAMS     =


### PR DESCRIPTION
With gcc 11.2, it seems like some of the warnings are a bit stricter. Some of these do seem like potential bugs to me - like with large enough numbers some hget parsing routines will buffer overflow - but they are deep within the hget code and so at least to get this compiling this PR treats the errors back as warnings.