### PR TITLE
Fixed the for loop condition and judgment condition of the get_cpu_affinity function

### DIFF
--- a/src/hashpipe_thread.c
+++ b/src/hashpipe_thread.c
@@ -99,7 +99,8 @@ list_hashpipe_threads(FILE * f)
 unsigned int
 get_cpu_affinity()
 {
-    int i, mask=0;
+    int i;
+    unsigned int mask=0;
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
 
@@ -108,14 +109,11 @@ get_cpu_affinity()
         hashpipe_error(__FUNCTION__, "Error getting cpu affinity.");
         return 0;
     }
-    if(mask != 0) {
-        // Only handle 32 cores (for now)
-        for(i=31; i<=0; i--) {
-            mask <<= 1;
-            if(CPU_ISSET(i, &cpuset)) {
-              mask |= 1;
-            }
-        }
+    // Only handle 32 cores (for now)
+    for(i=31; i>=0; i--) {
+        mask <<= 1;
+        if(CPU_ISSET(i, &cpuset)) {
+          mask |= 1;            }
     }
     return mask;
 }


### PR DESCRIPTION
1. Initialization of mask

mask is initialized to 0, but in later code, if (mask! = 0) This condition is meaningless because mask is always 0. This conditional judgment should be removed.

2. The loop condition is incorrect

Loop for (i = 31; i <= 0;  The condition of i--) is wrong. i <= 0 causes the loop to terminate immediately because the initial value of i is 31, which does not satisfy the condition of i <= 0. i >= 0 instead.